### PR TITLE
#135: remove 'sh' from bash_loader

### DIFF
--- a/bash/bash_loader
+++ b/bash/bash_loader
@@ -17,5 +17,5 @@ true "${haystack[@]}"
 
 # execute scripts in 'haystack'
 for file in "${haystack[@]}"; do  
- sh ./"$file" &
+ ./"$file" &
 done


### PR DESCRIPTION
Resolves #135.
